### PR TITLE
Fix erroneous deletion of links on repeated seaf2drawio runs

### DIFF
--- a/lib/link_manager.py
+++ b/lib/link_manager.py
@@ -1,4 +1,5 @@
 import xml.etree.ElementTree as ET
+import re
 from N2G import drawio_diagram
 
 def find_parent(root, target):
@@ -9,30 +10,38 @@ def find_parent(root, target):
                 return elem
     return None
 
+def normalize_id(link_id: str) -> str:
+    """Удаляет технические суффиксы, добавляемые при генерации диаграммы."""
+    return re.sub(r"_\d+$", "", link_id)
+
+
 def collect_data_links(object_data):
     """
     Собирает все связи из данных объекта.
     Проверяет различные возможные поля для связей.
     """
     data_links = set()
-    
+
     for source_id, targets in object_data.items():
         # Проверяем разные возможные ключи для связей
         possible_keys = ['location', 'network_connection', 'connections', 'links']
-        
+
         for key in possible_keys:
             if key in targets:
                 connections = targets[key]
                 # Убедимся, что это список
                 if not isinstance(connections, list):
                     connections = [connections]
-                
+
                 for target_id in connections:
                     # Используем кортеж (source, target) как ключ
-                    # Учитываем, что связи двунаправленные
-                    link_key = tuple(sorted([source_id, target_id]))
+                    # Учитывая, что связи двунаправленные, нормализуем идентификаторы
+                    link_key = tuple(sorted([
+                        normalize_id(source_id),
+                        normalize_id(target_id)
+                    ]))
                     data_links.add(link_key)
-                    
+
     return data_links
 
 def remove_obsolete_links(diagram, data_file, schema_key):
@@ -43,40 +52,38 @@ def remove_obsolete_links(diagram, data_file, schema_key):
     :param data_file: Путь к YAML-файлу с данными
     :param schema_key: Ключ схемы для поиска связей в данных
     """
-    # Получаем все связи из диаграммы
+    # Получаем связи из новых данных
+    from lib import seaf_drawio
+
+    # Загружаем данные
+    d = seaf_drawio.SeafDrawio({})
+
+    object_data = d.get_object(data_file, schema_key)
+    # Собираем связи из данных
+    data_links = collect_data_links(object_data)
+
+    # Собираем ID всех объектов выбранной схемы для фильтрации существующих связей
+    valid_ids = {normalize_id(obj_id) for obj_id in object_data.keys()}
+
+    # Получаем все связи из диаграммы только между объектами выбранной схемы
     existing_links = {}
-    
+
     # Работаем напрямую с XML-деревом диаграммы
     root = diagram.drawing
-    
-    # Ищем все элементы object с атрибутом edge (связи)
+
     for obj in root.iter('object'):
         cell = obj.find('mxCell')
         if cell is not None and cell.get('edge') == '1':
             source = cell.get('source')
             target = cell.get('target')
             if source and target:
-                # Используем кортеж (source, target) как ключ
-                # Учитываем, что связи двунаправленные
-                link_key = tuple(sorted([source, target]))
-                existing_links[link_key] = obj.get('id')
-    
-    # Получаем связи из новых данных
-    from lib import seaf_drawio
-    
-    # Загружаем данные
-    d = seaf_drawio.SeafDrawio({})
-    
-    # Для компонентов используем другую схему
-    if schema_key == 'seaf.ta.components.network':
-        object_data = d.get_object(data_file, schema_key)
-        # Собираем связи из данных
-        data_links = collect_data_links(object_data)
-    else:
-        # Для других схем используем оригинальный подход
-        object_data = d.get_object(data_file, schema_key)
-        # Собираем связи из данных
-        data_links = collect_data_links(object_data)
+                n_source = normalize_id(source)
+                n_target = normalize_id(target)
+                if n_source in valid_ids and n_target in valid_ids:
+                    # Используем кортеж (source, target) как ключ,
+                    # Учитываем, что связи двунаправленные
+                    link_key = tuple(sorted([n_source, n_target]))
+                    existing_links[link_key] = obj.get('id')
     
     # Определяем связи для удаления
     links_to_remove = set(existing_links.keys()) - data_links
@@ -88,7 +95,7 @@ def remove_obsolete_links(diagram, data_file, schema_key):
             print(f"  {link_key[0]} -> {link_key[1]}")
     else:
         print("Нет устаревших связей для удаления.")
-    
+
     # Удаляем устаревшие связи напрямую из XML
     for link_key in links_to_remove:
         link_id = existing_links[link_key]
@@ -98,3 +105,4 @@ def remove_obsolete_links(diagram, data_file, schema_key):
             parent = find_parent(root, obj)
             if parent is not None:
                 parent.remove(obj)
+


### PR DESCRIPTION
## Summary
- ignore technical ID suffixes when comparing diagram links with YAML data
- restrict deletion routine to links between network component nodes only

## Testing
- `python3 seaf2drawio.py -s data/example/test_seaf_ta_P41_v0.12.yaml -p data/base.drawio -d result/Sample_graph_from_base.drawio`
- `python3 seaf2drawio.py -s data/example/test_seaf_ta_P41_v0.12.yaml -p data/base_new.drawio -d result/Sample_graph_from_new2.drawio`

------
https://chatgpt.com/codex/tasks/task_e_6894e76404708320ae03492c48865469