### PR TITLE
Fix removal of obsolete links to avoid false deletions

### DIFF
--- a/lib/link_manager.py
+++ b/lib/link_manager.py
@@ -1,100 +1,101 @@
 import xml.etree.ElementTree as ET
-from N2G import drawio_diagram
 
 def find_parent(root, target):
-    """Находит родительский элемент для target в дереве root"""
+    """Находит родительский элемент для target в дереве root."""
     for elem in root.iter():
         for child in list(elem):
             if child is target:
                 return elem
     return None
 
-def collect_data_links(object_data):
-    """
-    Собирает все связи из данных объекта.
-    Проверяет различные возможные поля для связей.
-    """
+def collect_data_links(data):
+    """Собирает все связи из данных для всех схем."""
     data_links = set()
-    
-    for source_id, targets in object_data.items():
-        # Проверяем разные возможные ключи для связей
-        possible_keys = ['location', 'network_connection', 'connections', 'links']
-        
-        for key in possible_keys:
-            if key in targets:
-                connections = targets[key]
-                # Убедимся, что это список
-                if not isinstance(connections, list):
-                    connections = [connections]
-                
-                for target_id in connections:
-                    # Используем кортеж (source, target) как ключ
-                    # Учитываем, что связи двунаправленные
-                    link_key = tuple(sorted([source_id, target_id]))
+    possible_keys = ['location', 'network_connection', 'connections', 'links', 'segment']
+
+    segments = data.get('seaf.ta.services.network_segment', {})
+
+    def segment_locations(seg_id):
+        locs = []
+        seg = segments.get(seg_id)
+        if not seg:
+            return locs
+        def find_loc(attrs):
+            if isinstance(attrs, dict):
+                for k, v in attrs.items():
+                    if k == 'location':
+                        locs.extend(v if isinstance(v, list) else [v])
+                    else:
+                        find_loc(v)
+            elif isinstance(attrs, list):
+                for item in attrs:
+                    find_loc(item)
+        find_loc(seg)
+        return locs
+
+    def extract_links(source_id, attrs):
+        if isinstance(attrs, dict):
+            if 'source' in attrs and 'target' in attrs:
+                src = attrs['source']
+                targets = attrs['target'] if isinstance(attrs['target'], list) else [attrs['target']]
+                for tgt in targets:
+                    link_key = tuple(sorted([src, tgt]))
                     data_links.add(link_key)
-                    
+            for key, value in attrs.items():
+                if key in possible_keys:
+                    connections = value if isinstance(value, list) else [value]
+                    for target_id in connections:
+                        link_key = tuple(sorted([source_id, target_id]))
+                        data_links.add(link_key)
+                        if key == 'segment':
+                            for loc in segment_locations(target_id):
+                                link_key2 = tuple(sorted([source_id, loc]))
+                                data_links.add(link_key2)
+                else:
+                    extract_links(source_id, value)
+        elif isinstance(attrs, list):
+            for item in attrs:
+                extract_links(source_id, item)
+
+    for objects in data.values():
+        if not isinstance(objects, dict):
+            continue
+        for source_id, attrs in objects.items():
+            extract_links(source_id, attrs)
+
     return data_links
 
-def remove_obsolete_links(diagram, data_file, schema_key):
-    """
-    Удаляет связи из диаграммы, которые отсутствуют в новых данных.
-    
-    :param diagram: Экземпляр drawio_diagram
-    :param data_file: Путь к YAML-файлу с данными
-    :param schema_key: Ключ схемы для поиска связей в данных
-    """
-    # Получаем все связи из диаграммы
+def remove_obsolete_links(diagram, data_file):
+    """Удаляет связи из диаграммы, которые отсутствуют в данных."""
     existing_links = {}
-    
-    # Работаем напрямую с XML-деревом диаграммы
     root = diagram.drawing
-    
-    # Ищем все элементы object с атрибутом edge (связи)
+
     for obj in root.iter('object'):
         cell = obj.find('mxCell')
         if cell is not None and cell.get('edge') == '1':
             source = cell.get('source')
             target = cell.get('target')
             if source and target:
-                # Используем кортеж (source, target) как ключ
-                # Учитываем, что связи двунаправленные
                 link_key = tuple(sorted([source, target]))
                 existing_links[link_key] = obj.get('id')
-    
-    # Получаем связи из новых данных
+
     from lib import seaf_drawio
-    
-    # Загружаем данные
     d = seaf_drawio.SeafDrawio({})
-    
-    # Для компонентов используем другую схему
-    if schema_key == 'seaf.ta.components.network':
-        object_data = d.get_object(data_file, schema_key)
-        # Собираем связи из данных
-        data_links = collect_data_links(object_data)
-    else:
-        # Для других схем используем оригинальный подход
-        object_data = d.get_object(data_file, schema_key)
-        # Собираем связи из данных
-        data_links = collect_data_links(object_data)
-    
-    # Определяем связи для удаления
+    data_links = collect_data_links(d.read_and_merge_yaml(data_file))
+
     links_to_remove = set(existing_links.keys()) - data_links
-    
-    # Выводим информацию о связях, которые будут удалены
+
     if links_to_remove:
         print(f"Удаляем {len(links_to_remove)} устаревших связей:")
         for link_key in links_to_remove:
             print(f"  {link_key[0]} -> {link_key[1]}")
     else:
         print("Нет устаревших связей для удаления.")
-    
-    # Удаляем устаревшие связи напрямую из XML
+
     for link_key in links_to_remove:
         link_id = existing_links[link_key]
-        # Находим и удаляем элемент object с соответствующим ID
-        for obj in root.findall('.//object[@id="{}"]'.format(link_id)):
-            # Находим родителя и удаляем из него
+        for obj in root.findall(f'.//object[@id="{link_id}"]'):
             parent = find_parent(root, obj)
             if parent is not None:
                 parent.remove(obj)
+

--- a/seaf2drawio.py
+++ b/seaf2drawio.py
@@ -249,7 +249,7 @@ if __name__ == '__main__':
     diagram.from_xml(d.read_file_with_utf8(conf['drawio_pattern']))
     
     # Удаляем устаревшие связи перед добавлением новых
-    remove_obsolete_links(diagram, conf['data_yaml_file'], 'seaf.ta.components.network')
+    remove_obsolete_links(diagram, conf['data_yaml_file'])
     
     diagram_ids['Main Schema'] = list(d.get_object(conf['data_yaml_file'], root_object).keys())
     for file_name, pages in diagram_pages.items():


### PR DESCRIPTION
## Summary
- Traverse all data schemas to collect links, including segment-based and logical connections
- Remove obsolete Draw.io edges using the comprehensive link set
- Adjust main script to use updated link cleanup logic

## Testing
- `python seaf2drawio.py -p data/base.drawio -d result/Sample_graph_from_base.drawio`
- `python seaf2drawio.py -p data/base_new.drawio -d result/Sample_graph_from_new2.drawio`


------
https://chatgpt.com/codex/tasks/task_e_6894e76404708320ae03492c48865469